### PR TITLE
Add library documentation.

### DIFF
--- a/default.go
+++ b/default.go
@@ -8,6 +8,10 @@ func init() {
 	InitDefaultLogger()
 }
 
+// InitDefaultLogger creates new logger that writes log messages to
+// standard output in DEBUG level. This logger is automatically created and
+// this function needs to be called only if all loggers were removed
+// and default logger needs recreating.
 func InitDefaultLogger() {
 	var err error
 	_, err = NewLogger("default", DEBUG, []Handler{
@@ -22,24 +26,29 @@ func InitDefaultLogger() {
 	}
 }
 
+// Pause temporarily stops processing of log messages in default logger.
 func Pause() {
 	if logger, ok := loggers["default"]; ok {
 		logger.Pause()
 	}
 }
 
+// Unpause continues processing of log messages in default logger.
 func Unpause() {
 	if logger, ok := loggers["default"]; ok {
 		logger.Unpause()
 	}
 }
 
+// Stop permanently stops processing of log messages in default logger.
 func Stop() {
 	if logger, ok := loggers["default"]; ok {
 		logger.Stop()
 	}
 }
 
+// SetLevel sets maximum level for log messages that default logger
+// will process.
 func SetLevel(level Level) {
 	if logger, ok := loggers["default"]; ok {
 		logger.SetLevel(level)
@@ -52,120 +61,148 @@ func SetBufferLength(length int) {
 	}
 }
 
+// AddHandler adds new handler to default logger.
 func AddHandler(handler Handler) {
 	if logger, ok := loggers["default"]; ok {
 		logger.AddHandler(handler)
 	}
 }
 
+// ClearHandlers remove all handlers from default logger.
 func ClearHandlers() {
 	if logger, ok := loggers["default"]; ok {
 		logger.ClearHandlers()
 	}
 }
 
+// Logf logs provided message with formatting with default logger.
 func Logf(level Level, format string, a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(level, format, a...)
 	}
 }
 
+// Log logs provided message with default logger.
 func Log(level Level, a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(level, "", a...)
 	}
 }
 
+// Emergencyf logs provided message with formatting in EMERGENCY level
+// with default logger.
 func Emergencyf(format string, a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(EMERGENCY, format, a...)
 	}
 }
 
+// Emergency logs provided message in EMERGENCY level with default logger.
 func Emergency(a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(EMERGENCY, "", a...)
 	}
 }
 
+// Alertf logs provided message with formatting in ALERT level
+// with default logger.
 func Alertf(format string, a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(ALERT, format, a...)
 	}
 }
 
+// Alert logs provided message in ALERT level with default logger.
 func Alert(a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(ALERT, "", a...)
 	}
 }
 
+// Criticalf logs provided message with formatting in CRITICAL level
+// with default logger.
 func Criticalf(format string, a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(CRITICAL, format, a...)
 	}
 }
 
+// Critical logs provided message in CRITICAL level with default logger.
 func Critical(a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(CRITICAL, "", a...)
 	}
 }
 
+// Errorf logs provided message with formatting in ERROR level
+// with default logger.
 func Errorf(format string, a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(ERROR, format, a...)
 	}
 }
 
+// Error logs provided message in ERROR level with default logger.
 func Error(a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(ERROR, "", a...)
 	}
 }
 
+// Warningf logs provided message with formatting in WARNING level
+// with default logger.
 func Warningf(format string, a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(WARNING, format, a...)
 	}
 }
 
+// Warning logs provided message in WARNING level with default logger.
 func Warning(a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(WARNING, "", a...)
 	}
 }
 
+// Noticef logs provided message with formatting in NOTICE level
+// with default logger.
 func Noticef(format string, a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(NOTICE, format, a...)
 	}
 }
 
+// Notice logs provided message in NOTICE level with default logger.
 func Notice(a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(NOTICE, "", a...)
 	}
 }
 
+// Infof logs provided message with formatting in INFO level
+// with default logger.
 func Infof(format string, a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(INFO, format, a...)
 	}
 }
 
+// Info logs provided message in INFO level with default logger.
 func Info(a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(INFO, "", a...)
 	}
 }
 
+// Debugf logs provided message with formatting in DEBUG level
+// with default logger.
 func Debugf(format string, a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(DEBUG, format, a...)
 	}
 }
 
+// Debug logs provided message in DEBUG level with default logger.
 func Debug(a ...interface{}) {
 	if logger, ok := loggers["default"]; ok {
 		logger.log(DEBUG, "", a...)

--- a/documentation.go
+++ b/documentation.go
@@ -1,0 +1,25 @@
+// logging package is async logger library. It is based on idea that
+// log messages are created when client wants to log something, but
+// actual processing is done is designated goroutine. This means that
+// main application will not be blocked while logging is performed with
+// IO operations (writing to file, stdout/stderr, to socket).
+//
+// However, be warned that if your application panics and quits, it is
+// possible that some log messages will be lost, since they might not
+// be processed.
+//
+// Most simple way of using this module is by just importing it and
+// start logging. Default logger (that writes messages to stdout)
+// is created by default.
+//
+// Example:
+//
+//     import "resenje.org/logging"
+//     func main() {
+//         logging.Info("Some message")
+//         logging.WaitForAllUnprocessedRecords()
+//     }
+//
+// Since this is async logger, last line in main function is needed
+// because program will end before logger has a chance to process message.
+package logging

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,57 @@
+package logging
+
+import "fmt"
+
+// Utility stuff that is not very useful to show as part of example tests, but
+// that are needed in order to execute examples successful
+
+// custom formatter that does not modifiy provided message
+type PassThroughFormatter struct{}
+
+// Formatter interface implementation for PassThroughFormatter
+func (formatter *PassThroughFormatter) Format(record *Record) string {
+	return record.Message
+}
+
+// Shows basic example of using library without any setup.
+func Example_basic() {
+	// most basic way of using logging is by just calling logging functions
+	// without any setup. All these messages will be written to stdout.
+	Debug("Debug message")
+	Debugf("Debug message %s", "with formatting")
+	Info("Info message")
+	Infof("Info message %s", "with formatting")
+
+}
+
+// This example show how to create logger with specific name and custom
+// handlers.
+func Example_custom() {
+
+	// handler that writes all log messages to memory
+	// PassThroughFormatter only returns messages provided, without any modification
+	memoryHandler := &MemoryHandler{
+		Level:     WARNING,
+		Formatter: &PassThroughFormatter{},
+	}
+
+	if _, err := NewLogger("myLogger", WARNING, []Handler{memoryHandler}, 0); err != nil {
+		panic(err)
+	}
+
+	// this will probably be called somewhere else in the code
+	if logger, err := GetLogger("myLogger"); err != nil {
+		panic(err)
+	} else {
+		logger.Infof("Should not be logged")
+		logger.Error("Should be logged")
+
+	}
+
+	// wait for all messages to be processed, this is blocking
+	WaitForAllUnprocessedRecords()
+
+	fmt.Printf("%v\n", memoryHandler.Messages)
+
+	// Output: [Should be logged]
+}

--- a/file_handler.go
+++ b/file_handler.go
@@ -6,6 +6,12 @@ import (
 	"sync"
 )
 
+// Handler that writes log messages to file.
+// If file on provided path does not exist it will be created.
+//
+// Note that this handler does not perform any kind of file rotation or
+// truncation, so files will grow indefinitly. You might want to check out
+// RotatingFileHandler and
 type FileHandler struct {
 	NullHandler
 
@@ -19,6 +25,7 @@ type FileHandler struct {
 	lock   sync.RWMutex
 }
 
+// GetLevel returns minimal log level that this handler will process.
 func (handler *FileHandler) GetLevel() Level {
 	return handler.Level
 }
@@ -47,6 +54,8 @@ func (handler *FileHandler) open() error {
 	return nil
 }
 
+// Close releases resources used by this handler (file that log messages
+// were written into).
 func (handler *FileHandler) Close() error {
 	handler.lock.Lock()
 	defer handler.lock.Unlock()
@@ -70,6 +79,7 @@ func (handler *FileHandler) close() error {
 	return nil
 }
 
+// Handle writes message from log record into file.
 func (handler *FileHandler) Handle(record *Record) error {
 	handler.lock.Lock()
 	defer handler.lock.Unlock()

--- a/formatters.go
+++ b/formatters.go
@@ -11,14 +11,21 @@ const (
 	tolerance          = 25 * time.Millisecond
 )
 
+// Formatter is interface for defining new custom log messages formats.
 type Formatter interface {
+	// Should return string that represents log message based on provided Record.
 	Format(record *Record) string
 }
 
+// StandardFormatter adds time of logging with message to be logged.
 type StandardFormatter struct {
 	TimeFormat string
 }
 
+// Format constructs string for logging. Time of logging is added to log message.
+// Also, if time of logging is more then 25 miliseconds in the passt, both
+// times will be added to message (time when application sent log and time when
+// message was processed). Otherwise, only time of processing will be written.
 func (formatter *StandardFormatter) Format(record *Record) string {
 	var message string
 	now := time.Now()
@@ -30,8 +37,10 @@ func (formatter *StandardFormatter) Format(record *Record) string {
 	return fmt.Sprintf("[%v] %v %v", now.Format(formatter.TimeFormat), record.Level, message)
 }
 
+// JsonFormatter creates JSON struct with provided record.
 type JsonFormatter struct{}
 
+// Format creates JSON struct from provided record and returns it.
 func (formatter *JsonFormatter) Format(record *Record) string {
 	data, _ := json.Marshal(record)
 	return string(data)

--- a/handlers.go
+++ b/handlers.go
@@ -6,32 +6,44 @@ import (
 	"sync"
 )
 
+// Handler is interface that declares what every logging handler
+// must implement in order to be used with this library.
 type Handler interface {
+	// Handle should accept log record instance and process it.
 	Handle(record *Record) error
+	// HandleError should process errors that occured during calls to Handle method
 	HandleError(error) error
+	// GetLevel should return level that this handler is processing.
 	GetLevel() Level
+	// Close should free handler resources (opened files, etc)
 	Close() error
 }
 
+// NullHandler ignores all messages provided to it.
 type NullHandler struct{}
 
+// Handle ignores all messages.
 func (handler *NullHandler) Handle(record *Record) error {
 	return nil
 }
 
+// HandleError prints provided error to stderr.
 func (handler *NullHandler) HandleError(err error) error {
 	os.Stderr.WriteString(err.Error())
 	return nil
 }
 
+// GetLevel returns current level for this handler.
 func (handler *NullHandler) GetLevel() Level {
 	return DEBUG
 }
 
+// Close does nothing for this handler.
 func (handler *NullHandler) Close() error {
 	return nil
 }
 
+// Write handler requires io.Writer and sends all messages to this writer.
 type WriteHandler struct {
 	NullHandler
 
@@ -41,6 +53,7 @@ type WriteHandler struct {
 	lock      sync.RWMutex
 }
 
+// Handle writes all provided log records to writer provided during creation.
 func (handler *WriteHandler) Handle(record *Record) error {
 	handler.lock.Lock()
 	defer handler.lock.Unlock()
@@ -49,10 +62,13 @@ func (handler *WriteHandler) Handle(record *Record) error {
 	return err
 }
 
+// GetLevel returns current level for this handler.
 func (handler *WriteHandler) GetLevel() Level {
 	return handler.Level
 }
 
+// MemoryHandler stores all messages in memory.
+// If needed, messages can be obtained from Messages field.
 type MemoryHandler struct {
 	NullHandler
 
@@ -62,6 +78,7 @@ type MemoryHandler struct {
 	lock      sync.RWMutex
 }
 
+// Handle appends message to Messages array.
 func (handler *MemoryHandler) Handle(record *Record) error {
 	handler.lock.Lock()
 	defer handler.lock.Unlock()
@@ -70,6 +87,7 @@ func (handler *MemoryHandler) Handle(record *Record) error {
 	return nil
 }
 
+// GetLevel returns current level for this handler.
 func (handler *MemoryHandler) GetLevel() Level {
 	return handler.Level
 }

--- a/levels.go
+++ b/levels.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 )
 
+// Levels of logging supported by library.
+// They are ordered in descending order or imporance.
 const (
 	EMERGENCY Level = iota
 	ALERT
@@ -21,8 +23,10 @@ const (
 	running
 )
 
+// Level represents log level for log message.
 type Level int8
 
+// String returns stirng representation of log level.
 func (level Level) String() string {
 	switch level {
 	case EMERGENCY:
@@ -44,6 +48,8 @@ func (level Level) String() string {
 	}
 }
 
+// MarshalJSON is implementation of json.Marshaler interface, will be used when
+// log level is serialized to json.
 func (level Level) MarshalJSON() ([]byte, error) {
 	return json.Marshal(level.String())
 }

--- a/logging.go
+++ b/logging.go
@@ -15,6 +15,14 @@ var (
 	lock    = &sync.RWMutex{}
 )
 
+// Logger is struct that is capable of processing log messages.
+// It is central point of application logging configuration. Application
+// can have multiple loggers with different names and at moment of logging
+// logger is chosen.
+//
+// Each logger has level and ignores all log records below defined
+// level. Also, each logger has array of handlers used to to actuall log
+// record processing.
 type Logger struct {
 	Name          string
 	Level         Level
@@ -28,6 +36,11 @@ type Logger struct {
 	countOut      uint64
 }
 
+// NewLogger creates and returns new logger instance with provided name, log level,
+// handlers and buffer length.
+// Name of logger has to be unique when it is created or error will be returned.
+// Log level is lowest level or log record that this logger will handle.
+// Log records (above defined log level) will be passed to all log handlers for processing.
 func NewLogger(name string, level Level, handlers []Handler, bufferLength int) (*Logger, error) {
 	lock.Lock()
 	defer lock.Unlock()
@@ -51,6 +64,8 @@ func NewLogger(name string, level Level, handlers []Handler, bufferLength int) (
 	return logger, nil
 }
 
+// GetLogger returns logger instance based on provided name.
+// If logger does not exist, error will be returned.
 func GetLogger(name string) (*Logger, error) {
 	logger, ok := loggers[name]
 	if !ok {
@@ -59,18 +74,29 @@ func GetLogger(name string) (*Logger, error) {
 	return logger, nil
 }
 
+// RemoveLogger deletes logger from global logger registry.
 func RemoveLogger(name string) {
 	lock.Lock()
 	defer lock.Unlock()
 	delete(loggers, name)
 }
 
+// RemoveLoggers removes all loggers from global logger registry.
+// After calling this, not loggers exist, so new ones has to be creaded
+// for logging to work.
 func RemoveLoggers() {
 	lock.Lock()
 	defer lock.Unlock()
 	loggers = make(map[string]*Logger)
 }
 
+// WaitForAllUnprocessedRecords blocks execution until all unprocessed
+// log records are processed.
+// Since this library implements async logging, it is possible to have
+// unprocessed logs at the moment when application is terminating.
+// In that case, log messages can be lost. This mehtods blocks execution
+// until all log records are processed, to ensure that all log messages
+// are handled.
 func WaitForAllUnprocessedRecords() {
 	var wg sync.WaitGroup
 	for _, logger := range loggers {
@@ -83,10 +109,12 @@ func WaitForAllUnprocessedRecords() {
 	wg.Wait()
 }
 
+// String returns logger name.
 func (logger *Logger) String() string {
 	return logger.Name
 }
 
+// run starts async log records processing.
 func (logger *Logger) run() {
 	defer func() {
 		logger.WaitForUnprocessedRecords()
@@ -123,6 +151,10 @@ recordLoop:
 	}
 }
 
+// WaitForUnprocessedRecords block execution until all unprocessed log records
+// for this logger are processed.
+// In order to wait for processing in all loggers, logging.WaitForAllUnprocessedRecords
+// can be used.
 func (logger *Logger) WaitForUnprocessedRecords() {
 	runtime.Gosched()
 	logger.Unpause()
@@ -148,25 +180,31 @@ func (logger *Logger) WaitForUnprocessedRecords() {
 	}
 }
 
+// closeHandlers calls Close for all handlers for this logger
+// to release resources.
 func (logger *Logger) closeHandlers() {
 	for _, handler := range logger.Handlers {
 		handler.Close()
 	}
 }
 
+// Pause temporarily stops processing of log messages in current logger.
 func (logger *Logger) Pause() {
 	logger.stateChannel <- paused
 }
 
+// Unpause continues processing of log messages in current logger.
 func (logger *Logger) Unpause() {
 	logger.stateChannel <- running
 }
 
+// Stop permanently stops processing of log messages in current logger.
 func (logger *Logger) Stop() {
 	logger.stateChannel <- stopped
 	logger.waiter.Wait()
 }
 
+// SetBufferLength sets lenth of buffer for accepting log records.
 func (logger *Logger) SetBufferLength(length int) {
 	logger.lock.Lock()
 	defer logger.lock.Unlock()
@@ -178,6 +216,7 @@ func (logger *Logger) SetBufferLength(length int) {
 	}
 }
 
+// AddHandler add new handler to current logger.
 func (logger *Logger) AddHandler(handler Handler) {
 	logger.lock.Lock()
 	defer logger.lock.Unlock()
@@ -185,6 +224,7 @@ func (logger *Logger) AddHandler(handler Handler) {
 	logger.flushBuffer()
 }
 
+// ClearHandlers removes all handlers from current logger.
 func (logger *Logger) ClearHandlers() {
 	logger.lock.Lock()
 	defer logger.lock.Unlock()
@@ -193,6 +233,7 @@ func (logger *Logger) ClearHandlers() {
 	logger.flushBuffer()
 }
 
+// SetLevel sets lowes level that current logger will process.
 func (logger *Logger) SetLevel(level Level) {
 	logger.lock.Lock()
 	logger.Level = level
@@ -220,6 +261,7 @@ func (logger *Logger) flushBuffer() {
 	}
 }
 
+// log creates log record and submits it for processing.
 func (logger *Logger) log(level Level, format string, a ...interface{}) {
 	var message string
 	if format == "" {
@@ -238,74 +280,92 @@ func (logger *Logger) log(level Level, format string, a ...interface{}) {
 	logger.recordChannel <- record
 }
 
+// Logf logs provided message with formatting.
 func (logger *Logger) Logf(level Level, format string, a ...interface{}) {
 	logger.log(level, format, a...)
 }
 
+// Log logs provided message.
 func (logger *Logger) Log(level Level, a ...interface{}) {
 	logger.log(level, "", a...)
 }
 
+// Emergencyf logs provided message with formatting in EMERGENCY level.
 func (logger *Logger) Emergencyf(format string, a ...interface{}) {
 	logger.log(EMERGENCY, format, a...)
 }
 
+// Emergency logs provided message in EMERGENCY level.
 func (logger *Logger) Emergency(a ...interface{}) {
 	logger.log(EMERGENCY, "", a...)
 }
 
+// Aleftf logs provided message with formatting in ALERT level.
 func (logger *Logger) Alertf(format string, a ...interface{}) {
 	logger.log(ALERT, format, a...)
 }
 
+// Aleft logs provided message in ALERT level.
 func (logger *Logger) Alert(a ...interface{}) {
 	logger.log(ALERT, "", a...)
 }
 
+// Criticalf logs provided message with formatting in CRITICAL level.
 func (logger *Logger) Criticalf(format string, a ...interface{}) {
 	logger.log(CRITICAL, format, a...)
 }
 
+// Critical logs provided message in CRITICAL level.
 func (logger *Logger) Critical(a ...interface{}) {
 	logger.log(CRITICAL, "", a...)
 }
 
+// Errorf logs provided message with formatting in ERROR level.
 func (logger *Logger) Errorf(format string, a ...interface{}) {
 	logger.log(ERROR, format, a...)
 }
 
+// Error logs provided message in ERROR level.
 func (logger *Logger) Error(a ...interface{}) {
 	logger.log(ERROR, "", a...)
 }
 
+// Warningf logs provided message with formatting in WARNING level.
 func (logger *Logger) Warningf(format string, a ...interface{}) {
 	logger.log(WARNING, format, a...)
 }
 
+// Warning logs provided message in WARNING level.
 func (logger *Logger) Warning(a ...interface{}) {
 	logger.log(WARNING, "", a...)
 }
 
+// Noticef logs provided message with formatting in NOTICE level.
 func (logger *Logger) Noticef(format string, a ...interface{}) {
 	logger.log(NOTICE, format, a...)
 }
 
+// Notice logs provided message in NOTICE level.
 func (logger *Logger) Notice(a ...interface{}) {
 	logger.log(NOTICE, "", a...)
 }
 
+// Infof logs provided message with formatting in INFO level.
 func (logger *Logger) Infof(format string, a ...interface{}) {
 	logger.log(INFO, format, a...)
 }
 
+// Info logs provided message in INFO level.
 func (logger *Logger) Info(a ...interface{}) {
 	logger.log(INFO, "", a...)
 }
 
+// Debugf logs provided message with formatting in DEBUG level.
 func (logger *Logger) Debugf(format string, a ...interface{}) {
 	logger.log(DEBUG, format, a...)
 }
 
+// Debug logs provided message in DEBUG level.
 func (logger *Logger) Debug(a ...interface{}) {
 	logger.log(DEBUG, "", a...)
 }

--- a/record.go
+++ b/record.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// Record is representation of single message that needs to be logged in single handler.
 type Record struct {
 	Time    time.Time `json:"time"`
 	Level   Level     `json:"level"`

--- a/rotating_file_handler.go
+++ b/rotating_file_handler.go
@@ -8,6 +8,9 @@ import (
 	"sync"
 )
 
+// RotatingFileHandler writes all log messages to file with capability to
+// rotate files once they reach defined size.
+// If file on provided path does not exist it will be created.
 type RotatingFileHandler struct {
 	NullHandler
 
@@ -27,6 +30,7 @@ type RotatingFileHandler struct {
 	lock     sync.RWMutex
 }
 
+// GetLevel returns minimal log level that this handler will process.
 func (handler *RotatingFileHandler) GetLevel() Level {
 	return handler.Level
 }
@@ -70,6 +74,8 @@ func (handler *RotatingFileHandler) open() error {
 	return nil
 }
 
+// Close releases resources used by this handler (file that log messages
+// were written into).
 func (handler *RotatingFileHandler) Close() error {
 	handler.lock.Lock()
 	defer handler.lock.Unlock()
@@ -168,6 +174,7 @@ func (handler *RotatingFileHandler) rotate() error {
 	return nil
 }
 
+// Handle writes message from log record into file.
 func (handler *RotatingFileHandler) Handle(record *Record) error {
 	handler.lock.Lock()
 	defer handler.lock.Unlock()

--- a/syslog_handler.go
+++ b/syslog_handler.go
@@ -6,6 +6,7 @@ import (
 	"log/syslog"
 )
 
+// SyslogHandler sends all messages to syslog daemon.
 type SyslogHandler struct {
 	NullHandler
 


### PR DESCRIPTION
I have, as exercise in reading golang code, added documentation for logging library. Every exported function have doc string (I hope that I did not miss any).

I have added `documentation.go` with global overview of library.

Also, `example_test.go` contains two simple functions that show how this library can be used. These examples are executable tests and they are embedded in HTML documentation.

Since it is possible that I did not understand something correctly, I would be more then happy to correct any mistakes pointed out to me.
